### PR TITLE
ollama command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.12 - Ollama support enhancement
+
+- Now you can choose Ollama models on command palette (CTRL+SHIFT+P)
+
 ## 0.0.11 - Ollama support
 
 - Ollama support added

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This package empowers you with in-editor text completion capabilities, leveragin
 2.  **Configure Settings:** Specify your API endpoint URI and other parameters within the package settings.
 3.  **Compose Your Prompt:** Type your desired text into the editor.
 4.  **Position Cursor:** Place the cursor at the point where you want the LLM to generate text.
-5.  **Trigger Completion:** Invoke text completion by pressing CTRL+ALT+ENTER or navigating to "Assisted Writing: run" in the Command palette.
-6.  **Abort Completion (Optional):** Press ESC to stop the generation process if needed.
+5.  **Choose the model (Ollama only):** Choose desired model by navigating to "Assisted Writing: Ollama \*" in the Command palette.
+6.  **Trigger Completion:** Invoke text completion by pressing CTRL+ALT+ENTER or navigating to "Assisted Writing: run" in the Command palette.
+7.  **Abort Completion (Optional):** Press ESC to stop the generation process if needed.
 
 **Settings:**
 
@@ -30,8 +31,7 @@ This package empowers you with in-editor text completion capabilities, leveragin
   - **Params:** Customize API parameters to fine-tune the text generation behavior according to your requirements.
 - **Ollama Settings:** <!-- Added Ollama settings section -->
   - **Enable:** Enable to use Ollama as the backend.
-  - **Endpoint:** The URL of your Ollama server (default: `http://localhost:11434/api/generate`).
-  - **Model:** The name of the Ollama model you want to use (e.g., `llama3`).
+  - **Endpoint:** The URL of your Ollama server (default: `http://localhost:11434`).
   - **Params:** Additional model parameters for Ollama (e.g., temperature, top_k, top_p).
 - **Google AI Studio Gemini API Settings:**
   - **Enable:** When enable you can use Google AI Studio Gemini API

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -36,6 +36,15 @@ export default {
       this.backendMode = this.enabledBackends()[0]
     }
 
+    var ollamaModel =
+      (state.assistedWritingState && state.assistedWritingState.ollamaModel) ||
+      null
+    if (this.enabledModels().indexOf(ollamaModel) > -1) {
+      this.ollamaModel = ollamaModel
+    } else {
+      this.ollamaModel = null
+    }
+
     this.backendModeView.update(this.backendMode)
     // パネルクリックでbackendModeをトグルさせる
     this.backendModeView.getPanel().addEventListener('click', (e) => {
@@ -108,7 +117,10 @@ export default {
     return {
       tokenCountViewState: this.tokenCountView.serialize(),
       backendModeViewState: this.backendModeView.serialize(),
-      assistedWritingState: { backendMode: this.backendMode }, // backendMode を state に追加
+      assistedWritingState: { 
+        backendMode: this.backendMode, 
+        ollamaModel: this.ollamaModel // ollamaModel を state に追加
+      }, 
     }
   },
 
@@ -179,7 +191,11 @@ export default {
   setBackend(mode, model = null) {
     if (this.enabledBackends().indexOf(mode) >= 0) {
       this.backendMode = mode
-      this.ollamaModel = model
+      if (model != null && this.enabledModels().includes(model)) {
+        this.ollamaModel = model
+      } else {
+        this.ollamaModel = null
+      }
       if (model == null) {
         this.backendModeView.update(mode)
       } else {
@@ -239,6 +255,20 @@ export default {
     if (atom.config.get('assisted-writing.ollama.enable')) {
       // Add Ollama check
       ret.push('ollama')
+    }
+
+    return ret
+  },
+
+  enabledModels() {
+    var ret = []
+
+    if (this.backendMode === 'ollama') {
+      const endpointBase = atom.config.get(
+        'assisted-writing.ollama.endpointBase'
+      )
+      const models = await ollamaModels(endpointBase, () => {})
+      ret.push(...models)
     }
 
     return ret

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -77,8 +77,18 @@ export default {
         // 前回使用したモデル
         this.ollamaModel = ollamaModel
       } else {
-        // 存在しないモデルがstateに入っている、もしくは未設定だった場合先頭のモデルを使用
-        this.ollamaModel = models[0]
+        if (models.length > 0) {
+          // 存在しないモデルがstateに入っている、もしくは未設定だった場合先頭のモデルを使用
+          this.ollamaModel = models[0] // 先頭のモデルを使用
+        } else {
+          this.ollamaModel = null // Explicitly set to null if no models are available
+          atom.notifications.addWarning(
+            'No Ollama models found. Please check your Ollama setup or install a model.',
+            {
+              dismissable: true,
+            }
+          )
+        }
       }
 
       this.setOllamaModelCommands(models)

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -275,15 +275,11 @@ export default {
   },
 
   // Ollamaモデル選択コマンドの登録
-  async setOllamaModelCommands() {
+  setOllamaModelCommands(models) {
     this.ollamaCommands.dispose()
     this.ollamaCommands = new CompositeDisposable()
 
     if (atom.config.get('assisted-writing.ollama.enable')) {
-      const endpointBase = atom.config.get(
-        'assisted-writing.ollama.endpointBase'
-      )
-      const models = await ollamaModels(endpointBase, () => {})
       const commands = {}
       models.forEach((m) => {
         commands[`assisted-writing:ollama-${m}`] = () =>

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -60,7 +60,9 @@ export default {
 
     // Ollama固有処理
     const endpointBase = atom.config.get('assisted-writing.ollama.endpointBase')
-    const models = await ollamaModels(endpointBase, () => {})
+    const models = await ollamaModels(endpointBase, (e) => {
+      console.log(e)
+    })
 
     const ollamaModel =
       (state.assistedWritingState && state.assistedWritingState.ollamaModel) ||

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -61,7 +61,9 @@ export default {
     // Ollama固有処理
     const endpointBase = atom.config.get('assisted-writing.ollama.endpointBase')
     const models = await ollamaModels(endpointBase, (e) => {
-      console.log(e)
+      atom.notifications.addError('Ollamaとの通信エラーが発生しました。Ollamaが動作していることを確認してください。', {
+        dismissable: true,
+      })
     })
 
     const ollamaModel =

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -59,30 +59,46 @@ export default {
     }
 
     // Ollama固有処理
-    const endpointBase = atom.config.get('assisted-writing.ollama.endpointBase')
-    const models = await ollamaModels(endpointBase, (e) => {
-      atom.notifications.addError('Ollamaとの通信エラーが発生しました。Ollamaが動作していることを確認してください。', {
-        dismissable: true,
-      })
-    })
-
-    const ollamaModel =
-      (state.assistedWritingState && state.assistedWritingState.ollamaModel) ||
-      null
-    if (models.indexOf(ollamaModel) > -1) {
-      // 前回使用したモデル
-      this.ollamaModel = ollamaModel
-    } else {
-      // 存在しないモデルがstateに入っている、もしくは未設定だった場合先頭のモデルを使用
-      this.ollamaModel = models[0]
-    }
-
-    this.setOllamaModelCommands(models)
-    atom.config.observe('assisted-writing.ollama.enable', async () => {
+    if (atom.config.get('assisted-writing.ollama.enable')) {
       const endpointBase = atom.config.get(
         'assisted-writing.ollama.endpointBase'
       )
-      this.setOllamaModelCommands(await ollamaModels(endpointBase, () => {}))
+      const models = await ollamaModels(endpointBase, (e) => {
+        atom.notifications.addError('Is Ollama running?', {
+          dismissable: true,
+        })
+      })
+
+      const ollamaModel =
+        (state.assistedWritingState &&
+          state.assistedWritingState.ollamaModel) ||
+        null
+      if (models.indexOf(ollamaModel) > -1) {
+        // 前回使用したモデル
+        this.ollamaModel = ollamaModel
+      } else {
+        // 存在しないモデルがstateに入っている、もしくは未設定だった場合先頭のモデルを使用
+        this.ollamaModel = models[0]
+      }
+
+      this.setOllamaModelCommands(models)
+    }
+
+    atom.config.observe('assisted-writing.ollama.enable', async (v) => {
+      if (v) {
+        const endpointBase = atom.config.get(
+          'assisted-writing.ollama.endpointBase'
+        )
+        this.setOllamaModelCommands(
+          await ollamaModels(endpointBase, () => {
+            atom.notifications.addError('Is Ollama running?', {
+              dismissable: true,
+            })
+          })
+        )
+      } else {
+        this.setOllamaModelCommands([])
+      }
     })
 
     this.backendModeView.update(this.backendMode, this.ollamaModel)

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -21,42 +21,10 @@ export default {
   modalPanel: null,
   tokenCountView: null,
 
-  activate(state) {
+  async activate(state) {
     console.log('assisted-writing:activated')
     this.tokenCountView = new TokenCountView(state.tokenCountViewState)
     this.backendModeView = new BackendModeView(state.backendModeViewState)
-
-    // backendMode を state から読み込み、存在しない場合は初期値を最初に有効なバックエンドに設定
-    var backendMode =
-      (state.assistedWritingState && state.assistedWritingState.backendMode) ||
-      this.enabledBackends()[0]
-    if (this.enabledBackends().indexOf(backendMode) > -1) {
-      this.backendMode = backendMode
-    } else {
-      this.backendMode = this.enabledBackends()[0]
-    }
-
-    var ollamaModel =
-      (state.assistedWritingState && state.assistedWritingState.ollamaModel) ||
-      null
-    if (this.enabledModels().indexOf(ollamaModel) > -1) {
-      this.ollamaModel = ollamaModel
-    } else {
-      this.ollamaModel = null
-    }
-
-    this.backendModeView.update(this.backendMode)
-    // パネルクリックでbackendModeをトグルさせる
-    this.backendModeView.getPanel().addEventListener('click', (e) => {
-      this.setBackend(this.flipBackend(this.backendMode))
-    })
-
-    // 使用可能なバックエンドがない場合警告を出す
-    if (this.enabledBackends().length == 0) {
-      atom.notifications.addError('No enabled LLM backends', {
-        dismissable: true,
-      })
-    }
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable()
@@ -73,10 +41,51 @@ export default {
       })
     )
 
-    this.setOllamaModelCommands()
-    atom.config.observe('assisted-writing.ollama.enable', () =>
-      this.setOllamaModelCommands()
-    )
+    // backendMode を state から読み込み、存在しない場合は初期値を最初に有効なバックエンドに設定
+    var backendMode =
+      (state.assistedWritingState && state.assistedWritingState.backendMode) ||
+      this.enabledBackends()[0]
+    if (this.enabledBackends().indexOf(backendMode) > -1) {
+      this.backendMode = backendMode
+    } else {
+      this.backendMode = this.enabledBackends()[0]
+    }
+
+    // 使用可能なバックエンドがない場合警告を出す
+    if (this.enabledBackends().length == 0) {
+      atom.notifications.addError('No enabled LLM backends', {
+        dismissable: true,
+      })
+    }
+
+    // Ollama固有処理
+    const endpointBase = atom.config.get('assisted-writing.ollama.endpointBase')
+    const models = await ollamaModels(endpointBase, () => {})
+
+    const ollamaModel =
+      (state.assistedWritingState && state.assistedWritingState.ollamaModel) ||
+      null
+    if (models.indexOf(ollamaModel) > -1) {
+      // 前回使用したモデル
+      this.ollamaModel = ollamaModel
+    } else {
+      // 存在しないモデルがstateに入っている、もしくは未設定だった場合先頭のモデルを使用
+      this.ollamaModel = models[0]
+    }
+
+    this.setOllamaModelCommands(models)
+    atom.config.observe('assisted-writing.ollama.enable', async () => {
+      const endpointBase = atom.config.get(
+        'assisted-writing.ollama.endpointBase'
+      )
+      this.setOllamaModelCommands(await ollamaModels(endpointBase, () => {}))
+    })
+
+    this.backendModeView.update(this.backendMode, this.ollamaModel)
+    // パネルクリックでbackendModeをトグルさせる
+    this.backendModeView.getPanel().addEventListener('click', (e) => {
+      this.setBackend(this.flipBackend(this.backendMode))
+    })
 
     // init token count worker
     var tokenCountWorker = new Worker(
@@ -117,10 +126,10 @@ export default {
     return {
       tokenCountViewState: this.tokenCountView.serialize(),
       backendModeViewState: this.backendModeView.serialize(),
-      assistedWritingState: { 
-        backendMode: this.backendMode, 
-        ollamaModel: this.ollamaModel // ollamaModel を state に追加
-      }, 
+      assistedWritingState: {
+        backendMode: this.backendMode,
+        ollamaModel: this.ollamaModel, // ollamaModel を state に追加
+      },
     }
   },
 
@@ -191,16 +200,10 @@ export default {
   setBackend(mode, model = null) {
     if (this.enabledBackends().indexOf(mode) >= 0) {
       this.backendMode = mode
-      if (model != null && this.enabledModels().includes(model)) {
+      if (model != null) {
         this.ollamaModel = model
-      } else {
-        this.ollamaModel = null
       }
-      if (model == null) {
-        this.backendModeView.update(mode)
-      } else {
-        this.backendModeView.update(mode, model)
-      }
+      this.backendModeView.update(mode, this.ollamaModel)
     }
   },
 
@@ -255,20 +258,6 @@ export default {
     if (atom.config.get('assisted-writing.ollama.enable')) {
       // Add Ollama check
       ret.push('ollama')
-    }
-
-    return ret
-  },
-
-  enabledModels() {
-    var ret = []
-
-    if (this.backendMode === 'ollama') {
-      const endpointBase = atom.config.get(
-        'assisted-writing.ollama.endpointBase'
-      )
-      const models = await ollamaModels(endpointBase, () => {})
-      ret.push(...models)
     }
 
     return ret

--- a/lib/assisted-writing.js
+++ b/lib/assisted-writing.js
@@ -7,6 +7,7 @@ import BackendModeView from './backend-mode-view'
 import { CompositeDisposable } from 'atom'
 import GenerationService from './generation-service'
 import { config } from './config'
+import { ollamaModels } from './ollama-api.js'
 
 const runningClass = 'assisted-writing-running'
 
@@ -16,6 +17,7 @@ export default {
   config: config,
   generationService: null,
   subscriptions: null,
+  ollamaCommands: null,
   modalPanel: null,
   tokenCountView: null,
 
@@ -49,6 +51,7 @@ export default {
 
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable()
+    this.ollamaCommands = new CompositeDisposable()
 
     // Register command that toggles this view
     this.subscriptions.add(
@@ -58,8 +61,12 @@ export default {
         'assisted-writing:use-local-llm': () => this.setBackend('local'),
         'assisted-writing:use-google-ai-studio-gemini-api': () =>
           this.setBackend('gemini'),
-        'assisted-writing:use-ollama': () => this.setBackend('ollama'), // Add Ollama command
       })
+    )
+
+    this.setOllamaModelCommands()
+    atom.config.observe('assisted-writing.ollama.enable', () =>
+      this.setOllamaModelCommands()
     )
 
     // init token count worker
@@ -92,6 +99,7 @@ export default {
 
   deactivate() {
     this.subscriptions.dispose()
+    this.ollamaCommands.dispose()
     this.tokenCountView.destroy()
     this.backendModeView.destroy()
   },
@@ -132,7 +140,10 @@ export default {
 
     this.setRunningStatus(editor)
 
-    this.generationService = new GenerationService(this.backendMode)
+    this.generationService = new GenerationService(
+      this.backendMode,
+      this.ollamaModel
+    )
     await this.generationService.completion(
       text,
       (chunk) => {
@@ -165,10 +176,15 @@ export default {
     } catch (e) {}
   },
 
-  setBackend(mode) {
+  setBackend(mode, model = null) {
     if (this.enabledBackends().indexOf(mode) >= 0) {
       this.backendMode = mode
-      this.backendModeView.update(mode)
+      this.ollamaModel = model
+      if (model == null) {
+        this.backendModeView.update(mode)
+      } else {
+        this.backendModeView.update(mode, model)
+      }
     }
   },
 
@@ -226,5 +242,25 @@ export default {
     }
 
     return ret
+  },
+
+  // Ollamaモデル選択コマンドの登録
+  async setOllamaModelCommands() {
+    this.ollamaCommands.dispose()
+    this.ollamaCommands = new CompositeDisposable()
+
+    if (atom.config.get('assisted-writing.ollama.enable')) {
+      const endpointBase = atom.config.get(
+        'assisted-writing.ollama.endpointBase'
+      )
+      const models = await ollamaModels(endpointBase, () => {})
+      const commands = {}
+      models.forEach((m) => {
+        commands[`assisted-writing:ollama-${m}`] = () =>
+          this.setBackend('ollama', m)
+      })
+
+      this.ollamaCommands.add(atom.commands.add('atom-text-editor', commands))
+    }
   },
 }

--- a/lib/backend-mode-view.js
+++ b/lib/backend-mode-view.js
@@ -30,7 +30,7 @@ export default class BackendModeView {
     return this.backendModeTile
   }
 
-  update(mode) {
+  update(mode, model = null) {
     switch (mode) {
       case 'local':
         this.backendModeTileContent.textContent =
@@ -40,7 +40,7 @@ export default class BackendModeView {
         this.backendModeTileContent.textContent = 'Google AI Studio Gemini API'
         break
       case 'ollama': // Add Ollama case
-        this.backendModeTileContent.textContent = 'Ollama'
+        this.backendModeTileContent.textContent = `${model}(Ollama)`
         break
       default:
         this.backendModeTileContent.textContent = 'Unknown'

--- a/lib/backend-mode-view.js
+++ b/lib/backend-mode-view.js
@@ -40,7 +40,7 @@ export default class BackendModeView {
         this.backendModeTileContent.textContent = 'Google AI Studio Gemini API'
         break
       case 'ollama': // Add Ollama case
-        this.backendModeTileContent.textContent = `${model}(Ollama)`
+        this.backendModeTileContent.textContent = model ? `${model}(Ollama)` : 'Ollama (No Model Selected)';
         break
       default:
         this.backendModeTileContent.textContent = 'Unknown'

--- a/lib/config.js
+++ b/lib/config.js
@@ -84,18 +84,11 @@ const config = {
         type: 'boolean',
         default: false,
       },
-      endpoint: {
+      endpointBase: {
         title: 'Endpoint',
         type: 'string',
-        default: 'http://localhost:11434/api/generate',
+        default: 'http://localhost:11434',
         description: 'Ollama API endpoint URI',
-      },
-      model: {
-        // Add model setting for Ollama
-        title: 'Model',
-        type: 'string',
-        default: 'llama3', // Or any default Ollama model
-        description: 'Ollama model to use',
       },
       params: {
         // Add params setting for Ollama

--- a/lib/generation-service.js
+++ b/lib/generation-service.js
@@ -5,8 +5,9 @@ import { ollamaApi, ollamaAbort } from './ollama-api.js'
 import { geminiApi, geminiApiAbort } from './gemini-api.js'
 
 export default class GenerationService {
-  constructor(type) {
+  constructor(type, model = null) {
     this.type = type
+    this.model = model
   }
 
   async completion(text, onChunkReceived, onError) {
@@ -56,11 +57,10 @@ export default class GenerationService {
         return false
       }
 
-      const endpoint = atom.config.get('assisted-writing.ollama.endpoint')
-      const model = atom.config.get('assisted-writing.ollama.model')
+      const endpoint = atom.config.get('assisted-writing.ollama.endpointBase')
       const params = {
         ...JSON.parse(atom.config.get('assisted-writing.ollama.params')),
-        ...{ prompt: text, model: model }, // Include prompt and model
+        ...{ prompt: text, model: this.model }, // Include prompt and model
         raw: true,
       }
       await ollamaApi(params, endpoint, onChunkReceived, onError)

--- a/lib/ollama-api.js
+++ b/lib/ollama-api.js
@@ -3,7 +3,8 @@
 //Ollama用のfetch処理, abort処理
 let ollamaAbortController = null
 
-const ollamaApi = async (params, endpoint, onChunkReceived, onError) => {
+const ollamaApi = async (params, endpointBase, onChunkReceived, onError) => {
+  const endpoint = `${endpointBase}/api/generate`
   ollamaAbortController = new AbortController()
   const options = {
     method: 'POST',
@@ -55,7 +56,7 @@ const ollamaAbort = () => {
   }
 }
 
-const ollamaModels = async (endpointBase, onSuccess, onError) => {
+const ollamaModels = async (endpointBase, onError) => {
   const endpoint = endpointBase + '/api/tags'
   try {
     const response = await fetch(endpoint)
@@ -63,8 +64,8 @@ const ollamaModels = async (endpointBase, onSuccess, onError) => {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
     const data = await response.json()
-    const modelNames = data.models.map(model => model.name)
-    onSuccess(modelNames)
+    const modelNames = data.models.map((model) => model.name)
+    return modelNames
   } catch (error) {
     onError(error)
   }

--- a/lib/ollama-api.js
+++ b/lib/ollama-api.js
@@ -68,6 +68,7 @@ const ollamaModels = async (endpointBase, onError) => {
     return modelNames
   } catch (error) {
     onError(error)
+    return []
   }
 }
 

--- a/lib/ollama-api.js
+++ b/lib/ollama-api.js
@@ -55,4 +55,18 @@ const ollamaAbort = () => {
   }
 }
 
-export { ollamaApi, ollamaAbort }
+const ollamaModels = async (endpointBase, onSuccess, onError) => {
+  const endpoint = endpointBase + '/api/tags'
+  try {
+    const response = await fetch(endpoint)
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+    const data = await response.json()
+    onSuccess(data.models)
+  } catch (error) {
+    onError(error)
+  }
+}
+
+export { ollamaApi, ollamaAbort, ollamaModels }

--- a/lib/ollama-api.js
+++ b/lib/ollama-api.js
@@ -63,7 +63,8 @@ const ollamaModels = async (endpointBase, onSuccess, onError) => {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
     const data = await response.json()
-    onSuccess(data.models)
+    const modelNames = data.models.map(model => model.name)
+    onSuccess(modelNames)
   } catch (error) {
     onError(error)
   }

--- a/menus/assisted-writing.json
+++ b/menus/assisted-writing.json
@@ -17,18 +17,6 @@
             {
               "label": "Run",
               "command": "assisted-writing:run"
-            },
-            {
-              "label": "use llama.cpp / text-generation webui",
-              "command": "assisted-writing:use-local"
-            },
-            {
-              "label": "use Google AI Studio Gemini API",
-              "command": "assisted-writing:use-gemini"
-            },
-            {
-              "label": "use Ollama",
-              "command": "assisted-writing:use-ollama"
             }
           ]
         }


### PR DESCRIPTION
- **/api/tagsを取れるように**
- **fix: ollamaModelsがモデル名のみの配列を返すように修正**
- **Ollamaが持っているモデル名に対応するコマンドを動的に登録するように**
- **feat: ollamaModelをstateに保存しリストアする機能追加**
- **refactor: `setOllamaModelCommands`にモデル名一覧を引数として渡すように変更**
- **メニュー項目を整理**
- **前回使用したOllamaモデルの設定を保持するように**
- **fix: エラーハンドリングを追加する**
- **fix: Ollama通信エラーメッセージを追加する**
- **Ollama使用時の説明を更新**
- **Ollamaが動いていない場合のnotification追加, Ollamaをdisableにしたときの挙動を改善**
- **update CHANGELOG**
